### PR TITLE
Join the room before posting

### DIFF
--- a/lib/lita/handlers/announce.rb
+++ b/lib/lita/handlers/announce.rb
@@ -159,8 +159,9 @@ module Lita
 
       def make_announcement_to_channels(payload)
         payload[:channels].each do |c|
-          channel = Lita::Source.new(room: Lita::Room.fuzzy_find(c))
-          robot.send_message(channel, "#{payload[:text]} - #{payload[:author]}")
+          room = Lita::Room.fuzzy_find(c)
+          robot.join(room)
+          robot.send_message(Lita::Source.new(room: room), "#{payload[:text]} - #{payload[:author]}")
         end
       end
 

--- a/spec/lita/handlers/announce_spec.rb
+++ b/spec/lita/handlers/announce_spec.rb
@@ -135,6 +135,9 @@ describe Lita::Handlers::Announce, lita_handler: true do
       end
 
       it "sends message" do
+        payload[:channels].each do |channel|
+          expect(robot).to receive(:join).with(Lita::Room.fuzzy_find(channel))
+        end
         send_command(command)
         expect(replies.length).to eql(payload[:channels].length)
         expect(replies.last).to eql(expected_message)


### PR DESCRIPTION
Ensure that the message can be posted successfully by joining the room
prior to sending the message.

Signed-off-by: Tom Duffield <tom@chef.io>